### PR TITLE
Optionally stop execution on error

### DIFF
--- a/R/Logging.R
+++ b/R/Logging.R
@@ -246,10 +246,12 @@ logInfo <- function(...) {
 #'
 #' @param ...   Zero or more objects which can be coerced to character (and which are pasted together
 #'              with no separator).
+#' @param warn  (Logical) Should the warning be printed to the R console? Default is FALSE.
 #' 
 #' @export
-logWarn <- function(...) {
+logWarn <- function(..., warn = FALSE) {
   log(level = "WARN", ...)
+  if (warn) warning(.makeMessage(...))
 }
 
 #' Log a message at the ERROR level
@@ -259,10 +261,12 @@ logWarn <- function(...) {
 #'
 #' @param ...   Zero or more objects which can be coerced to character (and which are pasted together
 #'              with no separator).
+#' @stop        (Logical) Should execution be stopped because of the error? Default is FALSE.
 #'
 #' @export
-logError <- function(...) {
+logError <- function(..., stop = FALSE) {
   log(level = "ERROR", ...)
+  if(stop) stop(.makeMessage(...))
 }
 
 #' Log a message at the FATAL level


### PR DESCRIPTION
Just throwing out an idea here.
```
logError("Some", "Error")
stop()
```
seems to be a common pattern in OHDSI tools. It would be nice if the error message was printed to the R console so the user immediately knows why (and possibly where) execution was halted. This pull request adds arguments to the `logError` and `logWarn` functions that allow for printing of the error or warning message to the R console.

The pattern then becomes
```
logError("Some", "Error", stop = TRUE)
```
and execution is stopped with an error message. I do not think existing code will be affected by this change but I'm not 100% sure about that.

It might be a bad idea to have an argument named the same as a built in function (stop). In this case it seems fine but I'm not sure.